### PR TITLE
Added a simple LSP

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,15 +8,15 @@
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/out/**/*.js"],
-            "preLaunchTask": "yarn: watch"
+            "preLaunchTask": "npm: watch"
+        },
+        {
+            "name": "Attach to Server",
+            "type": "node",
+            "request": "attach",
+            "port": 6009,
+            "restart": true,
+            "timeout": 10000
         }
-        // {
-        //   "name": "Attach to Server",
-        //   "type": "node",
-        //   "request": "attach",
-        //   "port": 6009,
-        //   "restart": true,
-        //   "timeout": 10000
-        // }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,27 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "yarn: watch",
-            "type": "shell",
-            "command": "yarn watch",
+            "type": "npm",
+            "script": "watch",
+            "group": "build",
             "isBackground": true,
-            "problemMatcher": ["$tsc-watch"]
+            "label": "npm: watch",
+            "detail": "webpack --watch",
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": ".",
+                        "file": 1,
+                        "location": 2,
+                        "message": 3
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Compiled successfully|webpack.*compiled.*"
+                }
+            }
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "activationEvents": [
         "onLanguage:pieuvre",
         "onCommand:vspieuvre.showProofPanel",
-        "onCommand:extension.goToDefinition",
-        "onCommand:extension.hoverInformation"
+        "onCommand:vspieuvre.goToDefinition",
+        "onCommand:vspieuvre.hoverInformation"
     ],
     "main": "./dist/extension.js",
     "contributes": {
@@ -124,7 +124,12 @@
         "simple-git-hooks": "^2.13.0",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12",
         "webpack": "^5.99.7",
         "webpack-cli": "^6.0.1"
+    },
+    "dependencies": {
+        "vscode-languageclient": "^9.0.1"
     }
 }

--- a/src/lsp/keywords.ts
+++ b/src/lsp/keywords.ts
@@ -1,0 +1,332 @@
+import { CompletionItem, CompletionItemKind } from 'vscode-languageserver';
+
+export const keywordCompletionItems: CompletionItem[] = [
+    // Keyword Control
+    {
+        label: 'Theorem',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a theorem',
+    },
+    {
+        label: 'Proposition',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a proposition',
+    },
+    {
+        label: 'Lemma',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a lemma',
+    },
+    {
+        label: 'Proof',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Starts a proof',
+    },
+    {
+        label: 'Qed',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Ends a proof',
+    },
+    {
+        label: 'Definition',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a definition',
+    },
+    {
+        label: 'Fixpoint',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a fixpoint',
+    },
+    {
+        label: 'Variable',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a variable',
+    },
+    {
+        label: 'Axiom',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines an axiom',
+    },
+    {
+        label: 'Parameter',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a parameter',
+    },
+    {
+        label: 'Hypothesis',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a hypothesis',
+    },
+    {
+        label: 'Goal',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines a goal',
+    },
+    {
+        label: 'Example',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Defines an example',
+    },
+    {
+        label: 'Print',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Prints a statement',
+    },
+    {
+        label: 'Check',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Checks a statement',
+    },
+    {
+        label: 'Undo',
+        kind: CompletionItemKind.Operator,
+        documentation: 'Undoes a statement',
+    },
+
+    // Keyword Operator
+    {
+        label: 'fun',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Defines a function',
+    },
+    {
+        label: 'match',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Matches a pattern',
+    },
+    {
+        label: 'with',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Used with match',
+    },
+    {
+        label: 'end',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Ends a block',
+    },
+    {
+        label: 'in',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Used in expressions',
+    },
+    {
+        label: 'let',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Defines a local variable',
+    },
+    {
+        label: 'if',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Conditional statement',
+    },
+    {
+        label: 'then',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Used with if',
+    },
+    {
+        label: 'else',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Used with if',
+    },
+    {
+        label: 'fix',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Fixes a value',
+    },
+    {
+        label: 'as',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Alias for a value',
+    },
+    {
+        label: 'return',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Returns a value',
+    },
+
+    // Keyword Type
+    {
+        label: 'Type',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Type of types',
+    },
+    {
+        label: 'Set',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Type of sets',
+    },
+    {
+        label: 'Prop',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Type of propositions',
+    },
+    {
+        label: 'nat',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Types of natural numbers',
+    },
+    {
+        label: 'bool',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Types of booleans',
+    },
+    {
+        label: 'list',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Types of lists',
+    },
+    {
+        label: 'option',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Types of options',
+    },
+    {
+        label: 'forall',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Check if a property is true for all values',
+    },
+    {
+        label: 'exists',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Check if a property is true for some value',
+    },
+    {
+        label: 'and',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Conjunction of two properties',
+    },
+    {
+        label: 'or',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Disjunction of two properties',
+    },
+    {
+        label: '\\~',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Negation of a property',
+    },
+    {
+        label: 'not',
+        kind: CompletionItemKind.Keyword,
+        documentation: 'Negation of a property',
+    },
+
+    // Storage Type
+    {
+        label: 'Inductive',
+        kind: CompletionItemKind.Constructor,
+        documentation: 'Defines an inductive type',
+    },
+
+    // Support Function
+    {
+        label: 'apply',
+        kind: CompletionItemKind.Function,
+        documentation: 'Applies a tactic',
+    },
+    {
+        label: 'auto',
+        kind: CompletionItemKind.Function,
+        documentation: 'Automatically applies tactics',
+    },
+    {
+        label: 'rewrite',
+        kind: CompletionItemKind.Function,
+        documentation: 'Rewrites a term',
+    },
+    {
+        label: 'simpl',
+        kind: CompletionItemKind.Function,
+        documentation: 'Simplifies a term',
+    },
+    {
+        label: 'reflexivity',
+        kind: CompletionItemKind.Function,
+        documentation: 'Proves reflexivity',
+    },
+    {
+        label: 'intro',
+        kind: CompletionItemKind.Function,
+        documentation: 'Introduces a variable',
+    },
+    {
+        label: 'intros',
+        kind: CompletionItemKind.Function,
+        documentation: 'Introduces multiple variables',
+    },
+    {
+        label: 'destruct',
+        kind: CompletionItemKind.Function,
+        documentation: 'Destructs a term',
+    },
+    {
+        label: 'induction',
+        kind: CompletionItemKind.Function,
+        documentation: 'Applies induction',
+    },
+    {
+        label: 'case',
+        kind: CompletionItemKind.Function,
+        documentation: 'Case analysis',
+    },
+    {
+        label: 'exact',
+        kind: CompletionItemKind.Function,
+        documentation: 'Exact match',
+    },
+    {
+        label: 'elim',
+        kind: CompletionItemKind.Function,
+        documentation: 'Eliminates a term',
+    },
+    {
+        label: 'inversion',
+        kind: CompletionItemKind.Function,
+        documentation: 'Inverts a term',
+    },
+    {
+        label: 'compute',
+        kind: CompletionItemKind.Function,
+        documentation: 'Computes a term',
+    },
+    {
+        label: 'assumption',
+        kind: CompletionItemKind.Function,
+        documentation: 'Assumption tactic',
+    },
+    {
+        label: 'cut',
+        kind: CompletionItemKind.Function,
+        documentation: 'Cut tactic',
+    },
+    {
+        label: 'try',
+        kind: CompletionItemKind.Function,
+        documentation: 'Try tactic',
+    },
+    {
+        label: 'fail',
+        kind: CompletionItemKind.Function,
+        documentation: 'Fail tactic',
+    },
+    {
+        label: 'assert',
+        kind: CompletionItemKind.Function,
+        documentation: 'Assert tactic',
+    },
+    {
+        label: 'idtac',
+        kind: CompletionItemKind.Function,
+        documentation: 'Identity tactic',
+    },
+    {
+        label: 'unfold',
+        kind: CompletionItemKind.Function,
+        documentation: 'Unfolds a term',
+    },
+];
+
+export const keywords = new Set(
+    keywordCompletionItems.map(({ label }) => label),
+);

--- a/src/lsp/server.ts
+++ b/src/lsp/server.ts
@@ -1,0 +1,260 @@
+import {
+    createConnection,
+    TextDocuments,
+    ProposedFeatures,
+    CompletionItem,
+    CompletionItemKind,
+    TextDocumentPositionParams,
+    DefinitionParams,
+    DidChangeTextDocumentParams,
+    Range,
+    Diagnostic,
+    Position,
+} from 'vscode-languageserver/node';
+
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { keywordCompletionItems, keywords } from './keywords';
+
+const connection = createConnection(ProposedFeatures.all);
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+
+interface IDefinitionItem {
+    completion: CompletionItem;
+    lineNum: number;
+    kind: string;
+}
+
+let definitions: Map<string, IDefinitionItem[]> = new Map();
+let lastProcessedVersion: number | null = null;
+
+connection.onInitialize((_) => {
+    console.log('LSP Initialized');
+
+    return {
+        capabilities: {
+            completionProvider: {
+                resolveProvider: true,
+            },
+            definitionProvider: true,
+            hoverProvider: true,
+        },
+    };
+});
+
+connection.onCompletion(
+    (textDocumentPosition: TextDocumentPositionParams): CompletionItem[] => {
+        const document = documents.get(textDocumentPosition.textDocument.uri);
+        if (document) {
+            debouncedUpdateAndRevalidate(document);
+        }
+
+        const completionItems = [...keywordCompletionItems];
+
+        // Add user-defined terms to completion items
+        definitions.forEach((l) => {
+            let lAfter = l.filter(
+                ({ lineNum }) => lineNum <= textDocumentPosition.position.line,
+            );
+            if (lAfter && lAfter.length > 0) {
+                completionItems.push(lAfter[lAfter.length - 1].completion);
+            }
+        });
+
+        return completionItems;
+    },
+);
+
+connection.onDefinition((params: DefinitionParams) => {
+    const document = documents.get(params.textDocument.uri);
+    if (!document) {
+        return null;
+    }
+
+    debouncedUpdateAndRevalidate(document);
+
+    const position = params.position;
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    const wordPattern = /\b\w+\b/g;
+    const line = lines[position.line];
+    const match = [...line.matchAll(wordPattern)].find(
+        (m) =>
+            position.character >= m.index! &&
+            position.character <= m.index! + m[0].length,
+    );
+
+    if (match) {
+        const word = match[0];
+
+        const allDefinitions = definitions
+            .get(word)
+            ?.filter(({ lineNum }) => lineNum <= position.line);
+
+        if (allDefinitions && allDefinitions.length > 0) {
+            const definition = allDefinitions[allDefinitions.length - 1];
+
+            return {
+                uri: params.textDocument.uri,
+                range: {
+                    start: { line: definition.lineNum, character: 0 },
+                    end: { line: definition.lineNum, character: 0 },
+                },
+            };
+        }
+    }
+
+    return null;
+});
+
+connection.onHover((params) => {
+    const document = documents.get(params.textDocument.uri);
+    if (!document) {
+        return null;
+    }
+
+    updateDefinitions(document);
+
+    const position = params.position;
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    const wordPattern = /\b\w+\b/g;
+    const line = lines[position.line];
+    const match = [...line.matchAll(wordPattern)].find(
+        (m) =>
+            position.character >= m.index! &&
+            position.character <= m.index! + m[0].length,
+    );
+
+    if (match && match.length > 0) {
+        const word = match[0];
+
+        // Some special logic to support shadowing
+        const allDefinitions = definitions
+            .get(word)
+            ?.filter(({ lineNum }) => lineNum <= position.line);
+
+        if (allDefinitions && allDefinitions.length > 0) {
+            const definition = allDefinitions[allDefinitions.length - 1];
+            return {
+                contents: {
+                    kind: 'markdown',
+                    value: `**${word}**\n\nDefined on line ${definition.lineNum + 1} as a ${definition.kind}.`,
+                },
+            };
+        }
+    }
+
+    return null;
+});
+
+connection.onCompletionResolve((item: CompletionItem): CompletionItem => item);
+
+function debounce<T extends (...args: any[]) => void>(fn: T, delay: number) {
+    let timeout: NodeJS.Timeout | null = null;
+    return (...args: Parameters<T>) => {
+        if (timeout) {
+            clearTimeout(timeout); // Clear the previous timeout
+        }
+        timeout = setTimeout(() => {
+            fn(...args);
+            timeout = null; // Reset the timeout
+        }, delay);
+    };
+}
+
+const debouncedUpdateAndRevalidate = debounce(updateAndRevalidate, 300);
+
+function updateAndRevalidate(document: TextDocument) {
+    if (document.version === lastProcessedVersion) return;
+
+    updateDefinitions(document);
+    validateVariableUsage(document);
+
+    lastProcessedVersion = document.version;
+}
+
+connection.onDidChangeTextDocument((params: DidChangeTextDocumentParams) => {
+    const document = documents.get(params.textDocument.uri);
+    if (!document) {
+        return null;
+    }
+
+    debouncedUpdateAndRevalidate(document);
+
+    return null;
+});
+
+function validateVariableUsage(document: TextDocument) {
+    const diagnostics: Diagnostic[] = [];
+    const text = document.getText();
+    const lines = text.split('\n');
+
+    const wordPattern = /\b\w+\b/g;
+
+    lines.forEach((line, lineNum) => {
+        const matches = [...line.matchAll(wordPattern)];
+        console.log(matches);
+        matches.forEach((match) => {
+            const word = match[0];
+
+            if (keywords.has(word)) return;
+
+            const character = match.index!;
+
+            const allDefinitions = definitions
+                .get(word)
+                ?.filter(({ lineNum: defLineNum }) => defLineNum <= lineNum);
+
+            if (!allDefinitions || allDefinitions.length === 0) {
+                diagnostics.push({
+                    severity: 1, // Error
+                    range: Range.create(
+                        Position.create(lineNum, character),
+                        Position.create(lineNum, character + word.length),
+                    ),
+                    message: `Variable "${word}" is not defined.`,
+                    source: 'LSP',
+                });
+            }
+        });
+    });
+
+    console.log(diagnostics);
+
+    // Send diagnostics to the client
+    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+}
+
+function updateDefinitions(document: TextDocument) {
+    definitions.clear();
+    const text = document.getText();
+    const lines = text.split('\n');
+    const definitionPattern =
+        /^\s*(Definition|Lemma|Proposition|Fixpoint|Inductive|\|)\s+(\w+).+?:.*$/;
+
+    lines.forEach((line, lineNum) => {
+        const match = line.match(definitionPattern);
+
+        if (match) {
+            const kind = match[1] == '|' ? 'Inductive Constructor' : match[1];
+            const name = match[2];
+            const completion: CompletionItem = {
+                label: name,
+                kind: CompletionItemKind.Variable,
+                documentation: `Definition of ${name} as "${kind}"`,
+            };
+
+            const allDefinitions = definitions.get(name);
+            if (allDefinitions) {
+                allDefinitions.push({ completion, lineNum, kind });
+            } else {
+                definitions.set(name, [{ completion, lineNum, kind }]);
+            }
+        }
+    });
+}
+
+documents.listen(connection);
+connection.listen();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,11 +12,14 @@ const extensionConfig = {
     target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
     mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
 
-    entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
+    entry: {
+        extension: './src/extension.ts',
+        lsp: './src/lsp/server.ts',
+    }, // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
     output: {
         // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
         path: path.resolve(__dirname, 'dist'),
-        filename: 'extension.js',
+        filename: '[name].js',
         libraryTarget: 'commonjs2',
     },
     externals: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,7 +1882,7 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.6:
+minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
@@ -2346,7 +2346,7 @@ schema-utils@^4.3.0, schema-utils@^4.3.2:
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
 
-semver@^7.3.4, semver@^7.5.3, semver@^7.6.0, semver@^7.6.2:
+semver@^7.3.4, semver@^7.3.7, semver@^7.5.3, semver@^7.6.0, semver@^7.6.2:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
@@ -2727,6 +2727,45 @@ vary@^1, vary@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vscode-jsonrpc@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz#f43dfa35fb51e763d17cd94dcca0c9458f35abf9"
+  integrity sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==
+
+vscode-languageclient@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz#cdfe20267726c8d4db839dc1e9d1816e1296e854"
+  integrity sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==
+  dependencies:
+    minimatch "^5.1.0"
+    semver "^7.3.7"
+    vscode-languageserver-protocol "3.17.5"
+
+vscode-languageserver-protocol@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz#864a8b8f390835572f4e13bd9f8313d0e3ac4bea"
+  integrity sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==
+  dependencies:
+    vscode-jsonrpc "8.2.0"
+    vscode-languageserver-types "3.17.5"
+
+vscode-languageserver-textdocument@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz#457ee04271ab38998a093c68c2342f53f6e4a631"
+  integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
+
+vscode-languageserver-types@3.17.5:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
+  integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
+
+vscode-languageserver@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz#500aef82097eb94df90d008678b0b6b5f474015b"
+  integrity sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==
+  dependencies:
+    vscode-languageserver-protocol "3.17.5"
 
 watchpack@^2.4.1:
   version "2.4.2"


### PR DESCRIPTION
Added a simple LSP that doesn't require a complex integration with pieuvre.
It's just "plug and play" (basically):
- the autocompletion results are the basic keywords and the user-defined variables, lemmas, *etc*
- the "go to definition" goes to the last definition (so it allows for shadowing)
- the "on hover" either gets a description of the keyword or is "defined on line *xx* as ..."
- that's about it!

Also, the "prover.stop" doesn't stop the "pieuvre" process, so maybe this should be fixed?

There is a more complete system working (with the "on hover" giving the types, and some annotations of unknown variables, bad syntax, *etc*), but it requires a lot of boilerplate on the pieuvre side... not ideal.